### PR TITLE
Allow for sub-string of affected code for whitelisting

### DIFF
--- a/gas-report-filter.go
+++ b/gas-report-filter.go
@@ -99,7 +99,7 @@ func retrieveCode(output string) string {
 /* #nosec */
 func isInWhitelist(whitelist Whitelist, file string, code string) bool {
 	for i := range whitelist.Issues {
-		if whitelist.Issues[i].File == file && whitelist.Issues[i].Code == code {
+		if whitelist.Issues[i].File == file && strings.Contains(whitelist.Issues[i].Code, code) {
 			return true
 		}
 	}


### PR DESCRIPTION
In the [newer version](https://github.com/securego/gosec/pull/497) of gosec (formerly known as gas), the affected code/line will now output the line numbers and the lines before and after the affected code/line. This complicates the process of whitelisting findings from gosec as our whitelist file requires the exact output code to be in the JSON.

For example, a whitelisted finding entry will now look like this:
```json
{
        "details": "Potential file inclusion via variable",
        "file": "/src/test/testHelper.go",
        "code": "53: func LoadTestFixtureAsString(t *testing.T, filename string) string {\n54: \tfixture, err := ioutil.ReadFile(filepath.Join(&#34;test-fixtures&#34;, filename))\n55: \tif err != nil {\n",
        "reason": "Code is only used for testing"
}
```
The `code` has to be manually escaped in order to exactly match what was supplied by gosec.

Given that we'll most probably be doing away with this report filter in the future, an interim stop-gap measure will be to allow for the `code` in the whitelist file to be a substring of the supplied code from gosec. This way it is easier to match and whitelist a finding.